### PR TITLE
Clarify the reference interface model

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ The 14 empty cells mark either industry gaps no production harness has
 filled yet, or topology-function combinations whose patterns haven't
 crystallized.
 
-Each pattern folder follows the same shape: `pattern.py` (the minimal
-honest reference, 50–250 lines), `example.py` (a real-scenario case that
-runs without API keys), `test_pattern.py` (the invariants the pattern
-must hold), and bilingual `README.md` / `README.zh-CN.md`.
+A completed pattern folder normally contains `pattern.py` (the minimal
+honest reference implementation), `test_pattern.py` (the invariants the
+pattern must hold), bilingual `README.md` / `README.zh-CN.md`, and, where
+available, an `example.py` that runs without API keys.
 
 ---
 
@@ -156,10 +156,37 @@ show the pattern in real production form, not toy form.
 * **Not a flat catalog.** A list answers *what patterns exist*. The matrix
   answers *where a problem sits* and *which patterns are wrong for that
   position*.
-* **Not toy code.** Every `pattern.py` is small (50–250 lines) on
-  purpose, but it is honest code with real invariants and tests. Each
-  `example.py` runs on data shaped like production. Engineering slices
+* **Not toy code.** Each `pattern.py` is scoped to the smallest honest
+  implementation of its invariants, with tests that pin those boundaries.
+  Examples, where present, use production-shaped data. Engineering slices
   in the READMEs cite verified upstream files.
+
+---
+
+## Interface model
+
+This repository publishes runnable reference interfaces, not an installable
+agent runtime or Python SDK.
+
+* `pattern.py` is the source of truth for a pattern's contract and minimal
+  implementation.
+* `test_pattern.py` is its executable specification and pins the invariants
+  that adaptations must preserve.
+* `example.py`, where present, demonstrates the pattern on production-shaped
+  data.
+* `shared.py` and framework notebooks are tutorial adapters, not stable public
+  APIs.
+* Collaboration patterns share `collaboration/boundary_contract.py`.
+* Governance patterns share `governance/boundary_contract.py`.
+* [`docs/INTERFACE-REGISTRY.md`](docs/INTERFACE-REGISTRY.md) is a generated
+  documentation index, not a runtime registry.
+
+`pip install -e ".[dev]"` installs the development dependencies used by this
+checkout. It does not install an importable `agent_design_patterns` package.
+Run examples from the cloned repository, or copy and adapt a pattern together
+with its tests. Pin the source commit when adopting or quoting an interface;
+the reference interfaces do not promise a shared runtime protocol or
+cross-version SDK compatibility.
 
 ---
 
@@ -169,6 +196,9 @@ show the pattern in real production form, not toy form.
 git clone https://github.com/huangjia2019/agent-design-patterns.git
 cd agent-design-patterns
 python -m venv .venv && source .venv/bin/activate
+
+# Install development and verification dependencies for this checkout.
+# This repository does not install an importable Python SDK.
 pip install -e ".[dev]"
 
 # Run a pattern's case
@@ -179,9 +209,11 @@ python perception/b-semantic-compaction/example.py
 pytest
 ```
 
-Each pattern folder is self-contained. No central framework, no plugin
-system to learn. Read the folder's README, look at `pattern.py`, run
-`example.py`, read the tests.
+Each pattern is independently readable and runnable from the checkout.
+Collaboration and governance patterns also use their row-level
+`boundary_contract.py`. There is no central framework or plugin system to
+learn: read the folder's README, inspect `pattern.py`, run the example when
+present, and read the tests.
 
 ---
 
@@ -192,14 +224,14 @@ system to learn. Read the folder's README, look at `pattern.py`, run
   README.md                # The why — what failure mode this pattern catches
   README.zh-CN.md          # 中文版
   pattern.py               # The minimal honest implementation
-  example.py               # A runnable case on production-shaped data
+  example.py               # A runnable case, where the folder provides one
   test_pattern.py          # The invariants the pattern must hold
 ```
 
 Read the README first — it's the *why* and the upstream slice. Then read
-`pattern.py` to see the smallest amount of code that solves it. Run
-`example.py` to see it work on data with shape. Tests pin the invariants
-you must not break when adapting.
+`pattern.py` to see the smallest amount of code that solves it. When an
+`example.py` is present, run it to see the pattern work on data with shape.
+Tests pin the invariants you must not break when adapting.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -85,7 +85,7 @@ Function × Execution Topology](https://arxiv.org/abs/2605.13850)**
 
 14 个空格子标的是工业还没填上的空白，或那种拓扑-功能组合下还没有结晶的模式。
 
-每个模式文件夹结构一致：`pattern.py`（最小诚实参考实现，50-250 行）+ `example.py`（拟真场景，无需 API key 也能跑）+ `test_pattern.py`（不变量测试）+ 中英双语 README。
+一个完成态的模式文件夹通常包含：`pattern.py`（最小诚实参考实现）、`test_pattern.py`（不变量测试）、中英双语 README，以及在适用时提供的 `example.py`（无需 API key 即可运行）。
 
 ---
 
@@ -118,7 +118,26 @@ Function × Execution Topology](https://arxiv.org/abs/2605.13850)**
 
 * **不是框架**。要生产 runtime，请用 [LangGraph](https://github.com/langchain-ai/langgraph)、[agno](https://github.com/agno-agi/agno)、[DeerFlow](https://github.com/bytedance/deer-flow) 或 [OpenHands](https://github.com/All-Hands-AI/OpenHands)。本仓库是你应用在它们之上的设计语言。换框架不改矩阵。
 * **不是平铺清单**。清单回答"有哪些模式存在"。矩阵回答**"你的问题落在哪儿、哪些模式是错位选择"**。
-* **不是 toy 代码**。每个 `pattern.py` 故意保持小（50-250 行），但里面是有真不变量、有测试的诚实代码。每个 `example.py` 跑在像生产数据的输入上。README 里的工程切片都是核对过的上游真实文件。
+* **不是 toy 代码**。每个 `pattern.py` 都围绕自身不变量保持最小诚实实现，并由测试固定这些边界。示例（如有）使用接近生产形态的数据。README 里的工程切片都是核对过的上游真实文件。
+
+---
+
+## 接口模型
+
+本仓库提供可运行的模式参考接口，不提供可安装的 Agent Runtime 或 Python SDK。
+
+* `pattern.py` 是模式契约和最小实现的代码真源。
+* `test_pattern.py` 是可执行规范，固定了改造时必须保留的不变量。
+* `example.py`（如有）用接近生产形态的数据展示模式的运行方式。
+* `shared.py` 和框架 Notebook 是教学适配层，不属于稳定公共 API。
+* 协作模式共享 `collaboration/boundary_contract.py`。
+* 治理模式共享 `governance/boundary_contract.py`。
+* [`docs/INTERFACE-REGISTRY.md`](docs/INTERFACE-REGISTRY.md) 是生成的接口文档索引，不是运行时注册表。
+
+`pip install -e ".[dev]"` 只为当前 checkout 安装开发和验证依赖，不会安装
+可导入的 `agent_design_patterns` Python 包。使用者应从克隆后的仓库运行
+示例，或将选定模式连同测试一起复制并改造。引用或采用接口时，应固定
+对应的源码提交；这些参考接口不承诺统一运行时协议或跨版本 SDK 兼容性。
 
 ---
 
@@ -128,6 +147,9 @@ Function × Execution Topology](https://arxiv.org/abs/2605.13850)**
 git clone https://github.com/huangjia2019/agent-design-patterns.git
 cd agent-design-patterns
 python -m venv .venv && source .venv/bin/activate
+
+# 为当前 checkout 安装开发和验证依赖。
+# 本仓库不会安装可导入的 Python SDK。
 pip install -e ".[dev]"
 
 # 跑一个模式的演示
@@ -138,7 +160,7 @@ python perception/b-semantic-compaction/example.py
 pytest
 ```
 
-每个模式文件夹自包含，没有中心框架，没有 plugin 系统要学。读文件夹的 README → 看 `pattern.py` → 跑 `example.py` → 看测试。
+每个模式都可以从当前 checkout 独立阅读和运行；协作与治理模式还会使用各自行级的 `boundary_contract.py`。这里没有中心框架或 plugin 系统需要学习：读文件夹的 README → 看 `pattern.py` → 在提供时运行 `example.py` → 看测试。
 
 ---
 
@@ -149,11 +171,11 @@ pytest
   README.md                # Why 段 + 工程切片引用
   README.zh-CN.md          # 中文版
   pattern.py               # 最小诚实实现
-  example.py               # 拟真场景，可跑
+  example.py               # 文件夹提供时可运行的拟真场景
   test_pattern.py          # 不变量测试
 ```
 
-先读 README 理解 why，再读 `pattern.py` 看最小解法，跑 `example.py` 看它在有 shape 的数据上的行为，测试钉死你改造时不该破坏的边界。
+先读 README 理解 why，再读 `pattern.py` 看最小解法；如果目录提供了 `example.py`，运行它观察模式在有 shape 的数据上的行为。测试钉死你改造时不该破坏的边界。
 
 ---
 


### PR DESCRIPTION
## Summary

- defines the repository-wide interface model in the English and Chinese root READMEs
- identifies `pattern.py` as the contract source of truth and `test_pattern.py` as its executable specification
- distinguishes tutorial adapters and the generated interface registry from stable runtime APIs
- documents the shared collaboration and governance boundary contracts
- clarifies that `pip install -e ".[dev]"` installs checkout tooling, not an importable Python SDK
- replaces absolute folder-size, self-contained, and example-availability claims with descriptions that match the current repository

## Why

The repository is a runnable reference-implementation catalog, but parts of the existing quickstart and folder description could be read as an installable, uniform Python library. The documentation should state the current consumption contract directly: clone, run, copy or adapt a pattern with its tests, and pin the source commit.

## Impact

Documentation only. No pattern implementation, test, notebook, or packaging behavior changes. The contract is defined once at the repository root rather than repeated across all pattern READMEs.

## Validation

- `git diff --check`
- `python3 -m pytest -q` — 555 passed